### PR TITLE
Changed button display type, updated height and margin of navbar h1 and ul margin-top

### DIFF
--- a/CSS/box model/Box-model mini project/box-project.css
+++ b/CSS/box model/Box-model mini project/box-project.css
@@ -27,6 +27,7 @@ ul {
     display: inline-block;
     list-style: none;
     padding-left: 0%;
+    margin-top: 0;
 }
 
 li {
@@ -37,9 +38,8 @@ li {
 .nav-head {
     font-size: 2.25em;
     display: inline-block;
-    margin-right: 40%;
-    margin-top: 0%;
-    margin-bottom: 0%;
+    margin: 0 25% 0 2.5%;
+    height: 80%;
     font-family: 'Goblin One', cursive;
 }
 
@@ -65,7 +65,10 @@ li {
 }
 
 button {
-    font-size: 1.5rem;
+    display: block;
+    /* Move the button onto a new line and allow use of vertical margins */
+    margin: 10px 10px;
+    font-size: 1.3rem;
     height: 35px;
     text-transform: uppercase;
     box-sizing: border-box;


### PR DESCRIPTION
The button was given a display of block so that it moves onto the next line and also be able to make use of vertical margins.
The button was given a smaller font size of 1.3rem to make it look more appropriately sized.

The navbar h1 was given a height of 80% of its container, removed the top and bottom border, margin of 2.5% of the container on the left and reduced the margin on the right down to 25%.
The code for the margin was also shrunk down to a single line to make the code less clunky.

The above was done so the h1 looks taller and takes up more vertical space in order to make it look more even in its place within the navbar and not too close to the left start of the document and top prevent the margin on the right from pushing the ul too far away.

Made the margin top of the ul 0 in order to move it slightly upwards and get it in line with the middle of the navbar h1.