### PR TITLE
Flex-box practice

### DIFF
--- a/CSS/flex/flex-2.css
+++ b/CSS/flex/flex-2.css
@@ -1,0 +1,43 @@
+body {
+    margin: 0;
+}
+
+header {
+    background: purple;
+    height: 100px;
+}
+
+h1 {
+    text-align: center;
+    color: white;
+    line-height: 100px;
+    margin: 0;
+}
+
+article {
+    flex: 200px;
+    padding: 10px;
+    margin: 10px;
+    background: aqua;
+}
+
+section {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    flex: 200px;
+    /* 
+    In the case that there are too many flex items to fit in the
+    width/height which leads to an overflow from a container, the
+    wrap value pushes the flex items onto the next line keeps
+    the layout.
+    This declaration has to be added to the parent container.
+    
+    NB: It is possible to reverse the order of the flex items by
+    using the row/column-reverse value.
+
+
+    A short-hand for this is to use flex-flow value where the
+    direction and the wrap can both be determined.
+    */
+}

--- a/CSS/flex/flex-2.html
+++ b/CSS/flex/flex-2.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+
+    <!-- CSS Link -->
+    <link rel="stylesheet" href="flex-2.css">
+
+    <title>Flexbox Practice 2</title>
+</head>
+<body>
+    <header>
+        <h1>Sample flexbox example</h1>
+      </header>
+    
+      <section>
+        <article>
+          <h2>First article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Second article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Third article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+    
+          <p>Cray food truck brunch, XOXO +1 keffiyeh pickled chambray waistcoat ennui. Organic small batch paleo 8-bit. Intelligentsia umami wayfarers pickled, asymmetrical kombucha letterpress kitsch leggings cold-pressed squid chartreuse put a bird on it. Listicle pickled man bun cornhole heirloom art party.</p>
+        </article>
+    
+        <article>
+          <h2>Fourth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Fifth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Sixth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+    
+          <p>Cray food truck brunch, XOXO +1 keffiyeh pickled chambray waistcoat ennui. Organic small batch paleo 8-bit. Intelligentsia umami wayfarers pickled, asymmetrical kombucha letterpress kitsch leggings cold-pressed squid chartreuse put a bird on it. Listicle pickled man bun cornhole heirloom art party.</p>
+        </article>
+    
+        <article>
+          <h2>Seventh article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Eighth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Ninth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+    
+          <p>Cray food truck brunch, XOXO +1 keffiyeh pickled chambray waistcoat ennui. Organic small batch paleo 8-bit. Intelligentsia umami wayfarers pickled, asymmetrical kombucha letterpress kitsch leggings cold-pressed squid chartreuse put a bird on it. Listicle pickled man bun cornhole heirloom art party.</p>
+        </article>
+    
+        <article>
+          <h2>Tenth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Eleventh article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+        </article>
+    
+        <article>
+          <h2>Twelfth article</h2>
+    
+          <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+    
+          <p>Cray food truck brunch, XOXO +1 keffiyeh pickled chambray waistcoat ennui. Organic small batch paleo 8-bit. Intelligentsia umami wayfarers pickled, asymmetrical kombucha letterpress kitsch leggings cold-pressed squid chartreuse put a bird on it. Listicle pickled man bun cornhole heirloom art party.</p>
+        </article>
+      </section>
+</body>
+</html>

--- a/CSS/flex/flex-align.css
+++ b/CSS/flex/flex-align.css
@@ -31,8 +31,6 @@ body {
     to the start point of the cross axis) and flex end
     (Aligns items to the end point of the cross axis)
 
-    Align-self overrides the align-items property if a specific
-    flex item is targeted.
     */
     justify-content: space-around;
     /* 
@@ -44,7 +42,34 @@ body {
     an equal amount of space on either side.
      NB: Space between is similar to space-around, but differs
      in that it doesn't leave space at either end.
+     Justify-items is ignored in flex layouts
     */
     height: 100px;
     border: 1px solid black;
+  }
+
+  button:first-child {
+    align-self: flex-end;
+    /* 
+    Align-self overrides the align-items property and targets 
+    individual flex items.
+    */
+    order: 1;
+    /* 
+    It is possible to change the order of flex items without affecting
+    the order of the original flex items. 
+    (This is not possible to do with other traditional layout methods)
+
+
+    1. The default order value for all flex items is 0, 
+    2. Flex items with the same order value will appea in their
+    original order
+    */
+  }
+  button:last-child {
+    order: -1;
+    /* 
+    It is possible to set negative values, which have the effect
+    of appearing before flex items with a value of 0.
+    */
   }

--- a/CSS/flex/flex-align.css
+++ b/CSS/flex/flex-align.css
@@ -1,0 +1,50 @@
+body {
+    width: 70%;
+    max-width: 960px;
+    margin: 20px auto;
+  }
+
+  button {
+    font-size: 18px;
+    line-height: 1.5;
+    width: 15%;
+  }
+
+  div {
+    display: flex;
+    align-items: center;
+    /* 
+    Align items controls where flex items sit on the cross axis
+    (ie: Perpendicular to the main axis).
+    therefore, if the flex direction is row, then a value of
+    align-items that is set to center will align the flex items
+    along the vertical axis.
+
+    The defaut for the align-items is stretch, which stretches the
+    flex items to fill the parent in the direction of the cross 
+    axis.
+        - If the parent doesn't have an explicit height set in the
+        cross direction, then the flex items will be equal to the
+        tallest flex item
+    
+    The other values for align-items are flex-start (Aligns items
+    to the start point of the cross axis) and flex end
+    (Aligns items to the end point of the cross axis)
+
+    Align-self overrides the align-items property if a specific
+    flex item is targeted.
+    */
+    justify-content: space-around;
+    /* 
+    Justify content controls where the flex items are aligned
+    along the main axis.
+
+    The default for justify-content is flex-start
+    The above value sorts items out evenly and then gives them
+    an equal amount of space on either side.
+     NB: Space between is similar to space-around, but differs
+     in that it doesn't leave space at either end.
+    */
+    height: 100px;
+    border: 1px solid black;
+  }

--- a/CSS/flex/flex-align.html
+++ b/CSS/flex/flex-align.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+
+    <!-- CSS Link -->
+    <link rel="stylesheet" href="flex-align.css">
+    
+    <title>Flexbox align 0 — starting code</title>
+    
+  </head>
+
+
+  
+  <body>
+
+    <div>
+      <button>Smile</button>
+      <button>Laugh</button>
+      <button>Wink</button>
+      <button>Shrug</button>
+      <button>Blush</button>
+    </div>
+
+
+
+  </body>
+</html>

--- a/CSS/flex/flex.css
+++ b/CSS/flex/flex.css
@@ -1,0 +1,3 @@
+body {
+    background: rgb(197, 197, 197);
+}

--- a/CSS/flex/flex.css
+++ b/CSS/flex/flex.css
@@ -15,7 +15,82 @@ h1 {
 }
 
 article {
+    flex: 1 200px;
+    /* 
+    The above declaration is a unitless proportion that
+    dictates the amount of available space on the main axis for
+    the flex item it is declared on relativeto the other flex
+    items.
+    
+    In the above case, all article elements in a flex container
+    will take up the same amount of space (ie: 1) after properties
+    like padding and margin have been set.
+
+
+    NB: The value for flex is proportianally set, therefore
+    regardless of the value entered, the end result is the same
+    for all the articles it is set on, unless you specifically
+    target one or more items to take up more space as seen in the 
+    below CSS rule
+    It is also possible to set a minimum size by adding a size
+    in addition to the flex value. In the above case, the flex
+    item will have a minimum value of 200px and thereafter, share
+    the available space in proportion with the other flex items.
+
+
+
+    Flex is shorthand for:
+    1. Flex-grow - The unitless proportion value which dictates
+        the amount of available space on the main axis relative
+        to the other items.
+    2. Flex-shrink - Another unitless proportion which dictates how
+        much a flex item will shrink whenever they overflow the
+        container
+    3. Flex-basis - The minimum value for flex items that was
+        previously mentioned.
+
+    *It is probablt best to use the longhand if it is needed to override something*
+    */
     padding: 10px;
     margin: 10px;
     background: aqua;
+}
+article:nth-of-type(3) {
+    flex: 2 200px;
+    /* 
+    The above declaration, which targets a specific element in
+    a flex container, makes it take up twice the amount of space
+    on the main axis (x-axis)
+    */
+}
+
+section {
+    display: flex;
+    /* 
+    This creates a makes section a flex-container and as a result the 
+    children element become equally sized flex columns.
+
+    Important notes"
+    1. Flex should only be set to parent elements with elements
+    that you wish to implement the flexbox layout on.
+
+    2. When display is set to flex, the parent element behaves as
+    a block level element and the child elements behave as 
+    flex-items, but if the desired behaviour of the child elements
+    is for them to act as inline elements, then a display of
+    inline-flex can be used, which still retains the flex layout.
+
+    3. The default layout is row (ie: The flex items are layed
+    out horizontally)
+    */
+    flex-direction: row;
+    /* 
+    The above declaration of flex-direction decides the direction
+    of theflex items
+    where row lays them out horizontally (left to right) and column
+    lays them out vertically (from top to bottom)
+
+    It is possible to reverse the direction in which the flex items
+    start and end by using the -reverse after row or column.
+    */
 }

--- a/CSS/flex/flex.css
+++ b/CSS/flex/flex.css
@@ -1,3 +1,21 @@
 body {
-    background: rgb(197, 197, 197);
+    margin: 0;
+}
+
+header {
+    background: purple;
+    height: 100px;
+}
+
+h1 {
+    text-align: center;
+    color: white;
+    line-height: 100px;
+    margin: 0;
+}
+
+article {
+    padding: 10px;
+    margin: 10px;
+    background: aqua;
 }

--- a/CSS/flex/flex.html
+++ b/CSS/flex/flex.html
@@ -6,7 +6,7 @@
     <title>Flexbox Practice</title>
 
     <!-- CSS Link -->
-    <link rel="stylesheet" href="">
+    <link rel="stylesheet" href="flex.css">
 
 
 
@@ -43,8 +43,5 @@
     </section>
 
 
-
-
-    
   </body>
 </html>

--- a/CSS/flex/flex.html
+++ b/CSS/flex/flex.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Flex Practice</title>
+
+    <!-- CSS Link -->
+    <link rel="stylesheet" href="flex.css">
+
+
+
+</head>
+<body>
+    
+</body>
+</html>

--- a/CSS/flex/flex.html
+++ b/CSS/flex/flex.html
@@ -1,18 +1,50 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Flex Practice</title>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Flexbox Practice</title>
 
     <!-- CSS Link -->
-    <link rel="stylesheet" href="flex.css">
+    <link rel="stylesheet" href="">
 
 
 
-</head>
-<body>
     
-</body>
+  </head>
+
+  <body>
+
+
+    <header>
+      <h1>Sample flexbox example</h1>
+    </header>
+
+    <section>
+      <article>
+        <h2>First article</h2>
+
+        <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+      </article>
+
+      <article>
+        <h2>Second article</h2>
+
+        <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+      </article>
+
+      <article>
+        <h2>Third article</h2>
+
+        <p>Tacos actually microdosing, pour-over semiotics banjo chicharrones retro fanny pack portland everyday carry vinyl typewriter. Tacos PBR&B pork belly, everyday carry ennui pickled sriracha normcore hashtag polaroid single-origin coffee cold-pressed. PBR&B tattooed trust fund twee, leggings salvia iPhone photo booth health goth gastropub hammock.</p>
+
+        <p>Cray food truck brunch, XOXO +1 keffiyeh pickled chambray waistcoat ennui. Organic small batch paleo 8-bit. Intelligentsia umami wayfarers pickled, asymmetrical kombucha letterpress kitsch leggings cold-pressed squid chartreuse put a bird on it. Listicle pickled man bun cornhole heirloom art party.</p>
+      </article>
+    </section>
+
+
+
+
+    
+  </body>
 </html>


### PR DESCRIPTION
Practiced the basics of flex-box layout and the flex short hand, wrapping flex items and how to align flex items in the flex html and CSS files, Flex-2 html and CSS files and flex-align html and CSS files respectively.

In the flex html and CSS files: I practiced the basics of flex-box layout and the flexbox shorthand which allows for the sizing of flex items and flex basis and flex grow.

In the flex-2 html and CSS files: I practiced the flex-wrap which allows for preventing the overflow of flex items.

In the flex-align html and CSS files: I practiced how to align flex items along the main axis using justify-content and along the cross axis (the axis which runs perpendicular to the flex direction that has been set).