### PR TITLE
Fixes #44

### DIFF
--- a/JavaScript/Projects/iPhoneCalculator/Calculator.js
+++ b/JavaScript/Projects/iPhoneCalculator/Calculator.js
@@ -435,6 +435,7 @@ window.addEventListener("keydown", function (evt) {
     } else if (evt.code === "Numpad9" || evt.code === "Digit9") {
         handleClick(nine.textContent)
     }
+    clear.textContent = 'C'
 })
 // The above event listeners use the evt object from the window object in order
 // to listen for any events that occur on the keyboard, and in this case, the
@@ -468,6 +469,7 @@ window.addEventListener("keydown", function (evt) {
             valueStrInMemory = null
             operatorInMemory = null
         }
+        clear.textContent = 'AC'
     }
 })
 

--- a/JavaScript/Projects/iPhoneCalculator/Calculator.js
+++ b/JavaScript/Projects/iPhoneCalculator/Calculator.js
@@ -135,6 +135,24 @@ const setDisplayStrAsValue = function (displayStrValue) {
         return;
     }
 
+    if (displayStrValue.length > 6) {
+        display.style.fontSize = '4rem'
+    } 
+    if (displayStrValue.length >= 7) {
+        display.style.fontSize = '3.5rem'
+    } 
+    if (displayStrValue.length >= 8) {
+        display.style.fontSize = '3rem'
+    }
+    if (displayStrValue.length <= 6) {
+        display.style.fontSize = '4.5rem'
+    }
+    // Tha above will adjust the font size of the numbers that are entered
+    // on the display of the calculator by reducing the font size by 0.5rem
+    // from the 6th digit onwards, but otherwise if the number of digits on the
+    // display is equal to or less than 6 digits, then the font size will be the
+    // same as wehat wsa computed on the CSS file.
+
     const [wholeNumStr, decimalNumStr] = displayStrValue.split('.')
 
     if (decimalNumStr) {
@@ -239,10 +257,15 @@ const handleOperators = function (operantion) {
 // For Numbers and Decimal
 for (let i = 0; i < allNumbers.length; i++) {
     const nthNum = allNumbers[i]
+    const currDisplayStr = getDisplayStrValue()
 
     nthNum.addEventListener('click', function () {
         handleClick(i.toString())
         clear.textContent = 'C'
+
+        if (currDisplayStr.length === 6) [
+            display.style.fontSize = '3rem'
+        ]
     })
 }
 // The for...loop is used to select all the number buttons and loop through all of


### PR DESCRIPTION
Fixed #44 by adding if statements for four different string lengths for the number that is on the display of the calculator from a user input.
The first if statement checks to see if the number from a user input is longer than six characters, if this evaluates to being true, then the font size for the numbers in the display should be set to 4rem.
The second if statement checks to see if the number from a user input is equal to, or longer than seven characters, if this evaluates to being true, then the font size for the numbers in the display should be set to 3.5rem.
The third if statement checks to see if the number from a user input is equal to, or longer than eight characters, if this evaluates to being true, then the font size for the numbers in the display should be set to 3rem.
The final if statement checks to see if the number from a user input is equal to or less than six characters, if this evaluates to being true, then the font size for the numbers in the display should be set to the default font size of 4.5rem, as set in the CSS.

I also left commented notes below the code to explain what I did.

There is also some code that was meant to be part of #47 which accidentally got bundled into this pull request, which is the assignment of the text content of the 'clear' function button, which was assigned to 'C' in the event listener for the keyboard inputs that represent numbers and 'AC' for any of the keyboard event listeners that represent the equals operator.