### PR TITLE
Fixes #64

### DIFF
--- a/JavaScript/Projects/Random Dad Joke Generator/dadJoke.css
+++ b/JavaScript/Projects/Random Dad Joke Generator/dadJoke.css
@@ -174,6 +174,14 @@ body {
     animation: right-img 2s linear forwards;
     animation-play-state: running;
 }
+.hide-left-img {
+    animation: hide-left-img 2s linear forwards;
+    animation-play-state: running;
+}
+.hide-right-img {
+    animation: hide-right-img 2s linear forwards;
+    animation-play-state: running;
+}
 
 @keyframes left-img {
     100% {
@@ -183,5 +191,21 @@ body {
 @keyframes right-img {
     100% {
         transform: translate(10px, -100px);
+    }
+}
+@keyframes hide-left-img {
+    0% {
+        transform: translate(-10px, -100px)
+    }
+    100% {
+        transform: translate(0px, 30px)
+    }
+}
+@keyframes hide-right-img {
+    0% {
+        transform: translate(10px, -100px);
+    }
+    100% {
+        transform: translate(0px, 30px);
     }
 }

--- a/JavaScript/Projects/Random Dad Joke Generator/dadJoke.js
+++ b/JavaScript/Projects/Random Dad Joke Generator/dadJoke.js
@@ -182,7 +182,7 @@ const showJoke = function () {
 
 
 // Animate Images
-const animateImg = function() {
+const animateImg = function () {
     imgs[selectImg]['a'].classList.add('img-left')
     imgs[selectImg]['b'].classList.add('img-right')
     imgs[selectImg]['a'].style.display = 'block'
@@ -200,6 +200,15 @@ const animateImg = function() {
 // The images are given a display of block to override the display that was
 // set in the CSS file for the images (this was done so the images don't interfere
 // with the rest of the application before the button for the joke is clicked)
+
+const hideImg = function () {
+    imgs[selectImg]['a'].classList.remove('img-left')
+    imgs[selectImg]['a'].classList.add('hide-left-img')
+    imgs[selectImg]['b'].classList.remove('img-right')
+    imgs[selectImg]['b'].classList.add('hide-right-img')
+
+    return
+}
 
 
 
@@ -239,8 +248,8 @@ askJoke.addEventListener('click', function () {
 
     const setupJoke = getJoke()
 
-    
-            if (setupJoke.length >= 55) {
+
+    if (setupJoke.length >= 55) {
         setTimeout(() => {
             display.textContent = showJoke()
 
@@ -255,9 +264,14 @@ askJoke.addEventListener('click', function () {
             // objects is equal to 0, then the value for selectImg should be
             // overriden to be 1 and if it is 4, then it should be overriden to
             // be overriden to be 3.
-            
-            
-        }, 8000)} else {
+
+            setTimeout(() => hideImg(), 5000)
+            // After 5 seconds, the images should be hidden with the hideImg()
+            // function expression.
+
+
+        }, 8000)
+    } else {
         setTimeout(() => {
             display.textContent = showJoke()
 
@@ -269,7 +283,10 @@ askJoke.addEventListener('click', function () {
             }
             animateImg()
 
-        }, 6000)}
+            setTimeout(() => hideImg(), 5000)
+                
+        }, 6000)
+    }
 
 
 
@@ -354,24 +371,24 @@ askJoke.addEventListener('click', function () {
 
     // Animate Elements
 
-        display.classList.add('animate-display')
+    display.classList.add('animate-display')
 
-        // The above adds a class that will be used for the display to add
-        // animations
+    // The above adds a class that will be used for the display to add
+    // animations
 
-    
-        askJoke.style.cssText = `
+
+    askJoke.style.cssText = `
         animation-name: shrink-btn;
         animation-duration: 2s;
         animation-timing-function: linear;
         animation-play-state: running;
         animation-fill-mode: forwards;
         `
-    
-        // The above code Reduces the font size for the text in the button
-        // so it does not compete with the display for the jokes.
-        // This is will be done with the use of animations that will be added
-        // in the CSS file with the use of keyframes.
+
+    // The above code Reduces the font size for the text in the button
+    // so it does not compete with the display for the jokes.
+    // This is will be done with the use of animations that will be added
+    // in the CSS file with the use of keyframes.
 
 })
 


### PR DESCRIPTION
Fixed #64 by creating the `hideImg()` function expression which removes the class of `img-left` and `img-right` and adds the classes of `hide-left-img` and `hide-right-img` which reverses the animation of the removed classes in the CSS file.
`hideImg()` is executed inside of a `setTimeout()` handler with a timeout of 5 seconds.